### PR TITLE
[recommend] handle the potential "nan" string in user's profile

### DIFF
--- a/recommender.py
+++ b/recommender.py
@@ -75,10 +75,11 @@ class recommender:
             self.n_feature, len(user_profile))
 
         # service & matchness scores from review dataset
-        s_score, m_score, _, _ = evaluation.calculate_scores(
+        s_score, m_score, _, _, n_valid_feature = evaluation.calculate_scores(
             user_profile.keys(), user_profile, self.review_dataframe, (self.service_weights, self.match_weights), verbose=verbose, n_service=self.n_service, n_feature=self.n_feature)
         if verbose:
-            print("\nservice score: {}\nmatchness score: {}".format(s_score, m_score))
+            print("\nnumber features used: {}\nservice score: {}\nmatchness score: {}".format(
+                n_valid_feature, s_score, m_score))
 
         # similarity between service description and user's goal
         d_score = similarity.calculate_scores(
@@ -130,7 +131,7 @@ def main():
     rr.init_weights()
 
     # dummy inupt from user: fixed feature, keywords of goal and rating for service & matchness
-    user_profile = {"ufeature1": "F", "ufeature2": "fr",
+    user_profile = {"ufeature1": "nan", "ufeature2": "fr",
                     "ufeature3": "U3", "ufeaure4": "CA"}
     user_goal = [['time', 0.5], ['talk', 0.5],
                  ['friendly', 0.5], ['advice', 0.5]]

--- a/review_score/evaluation.py
+++ b/review_score/evaluation.py
@@ -35,10 +35,12 @@ def calculate_scores(features, user_profile, df, weights, verbose=False, n_servi
     s_scores, m_scores = [], []
     f_s, f_m = [], []
     (s_weight, m_weight) = weights
+    n_valid_features = []
     for s in range(n_service):
+        n_valid_feature = n_feature
         service_df = df.loc[df["sID"] == s + 1]
         f_sscores, f_mscores = [], []
-        if len(service_df) == 0:
+        if len(service_df) == 0:    # nothing record for this service
             if verbose:
                 print(
                     "\tnothing mathces for service #{}! use dummy entry with all scores set to 2.5".format(s + 1))
@@ -47,13 +49,19 @@ def calculate_scores(features, user_profile, df, weights, verbose=False, n_servi
             dummy_socre = 2.5
             f_sscores = [dummy_socre for _ in range(n_feature)]
             f_mscores = [dummy_socre for _ in range(n_feature)]
-            # continue
-        else:
-            # print("into feautres")
-            for f in features:
+            n_valid_feature = 0
+        else:   # given the records of this service
+            for f in features:  # for every feature
+                if user_profile[f] == 'nan':    # nan string!
+                    # print("service #{} - {}={}".format(s, f, user_profile[f]))
+                    n_valid_feature -= 1   # this feature won't count
+                    f_sscores.append(0)
+                    f_mscores.append(0)
+                    # assign zero to feature's service score/matchness score
+                    continue
                 feature_df = service_df[service_df[f] == user_profile[f]]
                 n_entries = len(feature_df)
-                if n_entries == 0:
+                if n_entries == 0:  # if no entry matches, assign average score.
                     f_sscores.append(2.5)
                     f_mscores.append(2.5)
                     continue
@@ -61,19 +69,26 @@ def calculate_scores(features, user_profile, df, weights, verbose=False, n_servi
                 feature_mscores = feature_df["m_score"].values
                 f_sscores.append(_calulate_numercial(feature_sscores))
                 f_mscores.append(_calulate_numercial(feature_mscores))
-        s_score = np.dot(f_sscores, s_weight) / n_feature
-        m_score = np.dot(f_mscores, m_weight) / n_feature
+        if verbose:
+            print("\tfeature used={}, score{}\t{}".format(
+                s, n_valid_feature, f_sscores, f_mscores))
+        if n_valid_feature == 0:
+            s_score, m_score = 0, 0
+        else:
+            s_score = np.dot(f_sscores, s_weight) / n_valid_feature
+            m_score = np.dot(f_mscores, m_weight) / n_valid_feature
         # print(s + 1, s_score, m_score)
         s_scores.append(s_score)
         m_scores.append(m_score)
         f_s.append(f_sscores)
         f_m.append(f_mscores)
-    return s_scores, m_scores, f_s, f_m
+        n_valid_features.append(n_valid_feature)
+    return s_scores, m_scores, f_s, f_m, n_valid_features
 
 
 def update_weights(weights, user_profile, user_scores, choices, df, lr=0.01, verbose=False, n_service=N_SERVICE, n_feature=N_FEATURE):
     # calculation
-    s_score, m_score, f_s, f_m = calculate_scores(user_profile.keys(
+    s_score, m_score, f_s, f_m, n_valid_features = calculate_scores(user_profile.keys(
     ), user_profile, df, weights, verbose=verbose, n_service=n_service, n_feature=n_feature)
     s_weight, m_weight = weights    # unpack
     s_value, m_value = user_scores  # user's rating for service & matchness
@@ -129,7 +144,7 @@ def main():
     m_weights = np.random.random_sample(N_FEATURE)
 
     features = usr_profile.keys()
-    s_score, m_score, _, _ = calculate_scores(
+    s_score, m_score, _, _, _ = calculate_scores(
         features, usr_profile, df, (s_weights, m_weights))
 
     print(s_score, "\n", m_score)


### PR DESCRIPTION
Handle the potential "nan" field in the user's profile (which is one of the inputs to the recommendation system).

For example, if the n_feature = 5 and these two cases can be handled
- f1="F", u2="nan", u3="fr", u4="downtown", u5="ca"    (missing field is filled with placeholder "nan" string)
- f1="F", u2="U4", u3="en", u4="downtown", u5="eu"   (all filled out)

The philosophy behind is simply ignoring the empty feature during the calculation.